### PR TITLE
fix: build script adapt jdk8 and jdk17 (#121)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,13 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+
+      - name: Setup JDK 8
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
-          java-version: '8'
-          distribution: 'temurin'
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
+          version: '8'
+          architecture: x64
+          targets: 'JAVA_8_HOME'
+
+      - name: Setup JDK 17
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: '17'
+          architecture: x64
+
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+        
       - name: Get version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -35,7 +45,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          export use_docker_env=true
+          export use_docker_env=false
           pushd polaris-agent-build/bin
           bash ./build_docker.sh ${{ steps.get_version.outputs.VERSION }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,21 +9,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+
+      - name: Setup JDK 8
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
-          java-version: '8'
-          distribution: 'temurin'
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
+          version: '8'
+          architecture: x64
+          targets: 'JAVA_8_HOME'
+
+      - name: Setup JDK 17
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: '17'
+          architecture: x64
+
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
       - name: Get version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - name: Build
         id: build
         run: |
-          export use_docker_env=true
+          export use_docker_env=false
           pushd polaris-agent-build/bin
+          echo $JAVA_HOME
+          echo $JAVA_8_HOME
           bash ./build.sh ${{ steps.get_version.outputs.VERSION }}
           popd
           PACKAGE_NAME=$(ls | grep polaris-java-agent*.zip | sed -n '1p')

--- a/polaris-agent-build/bin/build.sh
+++ b/polaris-agent-build/bin/build.sh
@@ -26,9 +26,9 @@ cp "polaris-agent-build/conf/polaris-agent.config" "${folder_name}/conf"
 echo "start to build package"
 
 if [[ "${use_docker_env}" == "true" ]]; then
-  docker run --rm -u root -v "$(pwd)":/home/maven/project -w /home/maven/project maven:3.8.6-openjdk-8 mvn clean -B package --file pom.xml
+  docker run --rm -u root -v "$(pwd)":/home/maven/project -w /home/maven/project maven:3.8.6-openjdk-8 mvn clean -B package -X --file pom.xml
 else
-  mvn clean -B package --file pom.xml
+  mvn clean -B package -X --file pom.xml
 fi
 
 cp "polaris-agent-core/polaris-agent-core-bootstrap/target/polaris-agent-core-bootstrap.jar" "${folder_name}/"


### PR DESCRIPTION
* feat: support JDK9 to JDK11

* fix: resume example ip to 127

* fix: spring cloud 2020 plugins not supported jdk 12+

* feat: support xmllint install

* feat: add release xmllint

* update jdk to 17

* feat: add jdk8

* add jdk 17

* add maven debug command

* add maven debug -X

* set use_docker_env=false

* fix：docker build

**Please provide issue(s) of this PR:**
Fixes #

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [ ] Discovery
- [ ] Route
- [ ] RateLimit
- [ ] CircuitBreaker
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
